### PR TITLE
feat: Add namespace support to ClusterRole names

### DIFF
--- a/code/charts/kube-s3-operator/templates/_helpers.tpl
+++ b/code/charts/kube-s3-operator/templates/_helpers.tpl
@@ -24,6 +24,23 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create a fully qualified name for cluster-scoped resources (includes namespace).
+This ensures ClusterRoles and ClusterRoleBindings are unique across namespaces.
+*/}}
+{{- define "kube-s3-operator.clustername" -}}
+{{- if .Values.fullnameOverride }}
+{{- printf "%s-%s" .Release.Namespace .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- printf "%s-%s" .Release.Namespace .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s-%s" .Release.Namespace .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "kube-s3-operator.chart" -}}

--- a/code/charts/kube-s3-operator/templates/leader-election-rbac.yaml
+++ b/code/charts/kube-s3-operator/templates/leader-election-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "kube-s3-operator.fullname" . }}-leader-election-role
+  name: {{ include "kube-s3-operator.clustername" . }}-leader-election-role
   labels:
   {{- include "kube-s3-operator.labels" . | nindent 4 }}
 rules:

--- a/code/charts/kube-s3-operator/templates/manager-rbac.yaml
+++ b/code/charts/kube-s3-operator/templates/manager-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kube-s3-operator.fullname" . }}-manager-role
+  name: {{ include "kube-s3-operator.clustername" . }}-manager-role
   labels:
   {{- include "kube-s3-operator.labels" . | nindent 4 }}
 rules:
@@ -47,7 +47,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kube-s3-operator.fullname" . }}-manager-rolebinding
+  name: {{ include "kube-s3-operator.clustername" . }}-manager-rolebinding
   labels:
   {{- include "kube-s3-operator.labels" . | nindent 4 }}
 roleRef:

--- a/code/charts/kube-s3-operator/templates/metrics-auth-rbac.yaml
+++ b/code/charts/kube-s3-operator/templates/metrics-auth-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kube-s3-operator.fullname" . }}-metrics-auth-role
+  name: {{ include "kube-s3-operator.clustername" . }}-metrics-auth-role
   labels:
   {{- include "kube-s3-operator.labels" . | nindent 4 }}
 rules:
@@ -21,14 +21,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kube-s3-operator.fullname" . }}-metrics-auth-rolebinding
+  name: {{ include "kube-s3-operator.clustername" . }}-metrics-auth-rolebinding
   labels:
   {{- include "kube-s3-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{ include "kube-s3-operator.fullname" . }}-metrics-auth-role'
+  name: '{{ include "kube-s3-operator.clustername" . }}-metrics-auth-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "kube-s3-operator.fullname" . }}-controller-manager'
+  name: '{{ include "kube-s3-operator.clustername" . }}-controller-manager'
   namespace: '{{ .Release.Namespace }}'

--- a/code/charts/kube-s3-operator/templates/metrics-reader-rbac.yaml
+++ b/code/charts/kube-s3-operator/templates/metrics-reader-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kube-s3-operator.fullname" . }}-metrics-reader
+  name: {{ include "kube-s3-operator.clustername" . }}-metrics-reader
   labels:
   {{- include "kube-s3-operator.labels" . | nindent 4 }}
 rules:

--- a/code/charts/kube-s3-operator/templates/s3bucket-admin-rbac.yaml
+++ b/code/charts/kube-s3-operator/templates/s3bucket-admin-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kube-s3-operator.fullname" . }}-s3bucket-admin-role
+  name: {{ include "kube-s3-operator.clustername" . }}-s3bucket-admin-role
   labels:
   {{- include "kube-s3-operator.labels" . | nindent 4 }}
 rules:

--- a/code/charts/kube-s3-operator/templates/s3bucket-editor-rbac.yaml
+++ b/code/charts/kube-s3-operator/templates/s3bucket-editor-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kube-s3-operator.fullname" . }}-s3bucket-editor-role
+  name: {{ include "kube-s3-operator.clustername" . }}-s3bucket-editor-role
   labels:
   {{- include "kube-s3-operator.labels" . | nindent 4 }}
 rules:

--- a/code/charts/kube-s3-operator/templates/s3bucket-viewer-rbac.yaml
+++ b/code/charts/kube-s3-operator/templates/s3bucket-viewer-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kube-s3-operator.fullname" . }}-s3bucket-viewer-role
+  name: {{ include "kube-s3-operator.clustername" . }}-s3bucket-viewer-role
   labels:
   {{- include "kube-s3-operator.labels" . | nindent 4 }}
 rules:


### PR DESCRIPTION
## Problem
When attempting to install the operator in multiple namespaces, Helm fails with ClusterRole ownership conflict errors.

## Solution
- Added \`kube-s3-operator.clustername\` helper that includes namespace in cluster-scoped resource names
- Updated all ClusterRole and ClusterRoleBinding templates to use the new helper
- Allows multiple operator instances to coexist in different namespaces

## Testing
\`\`\`bash
# Install in s3-acme namespace
helm upgrade --install s3-operator --namespace s3-acme charts/kube-s3-operator/

# Install in s3-operator namespace (no conflict!)
helm upgrade --install s3-operator --namespace s3-operator charts/kube-s3-operator/

# Verify unique ClusterRoles
kubectl get clusterroles | grep s3
\`\`\`

## Changes
- Modified \`_helpers.tpl\` to add namespace-aware helper
- Updated all ClusterRole templates in \`templates/\` directory

Fixes #[issue-number] (if you have an issue tracking this)