### PR TITLE
feat: make AWS credentials optional in Helm chart

### DIFF
--- a/code/charts/kube-s3-operator/templates/NOTES.txt
+++ b/code/charts/kube-s3-operator/templates/NOTES.txt
@@ -8,3 +8,78 @@ Please choose another release name when installing this chart, for example:
 
 Thank you for installing {{ .Chart.Name }}!
 
+=== AWS Credentials Configuration ===
+{{- if .Values.awsCredentials.enabled }}
+
+✅ AWS credentials are ENABLED
+
+The controller will attempt to use the Kubernetes secret '{{ .Values.awsCredentials.secretName }}'
+in the '{{ .Release.Namespace }}' namespace.
+
+⚠️ IMPORTANT: Make sure the secret exists BEFORE the controller starts, otherwise the pods will fail!
+
+Create the secret with your AWS credentials:
+
+  kubectl create secret generic {{ .Values.awsCredentials.secretName }} \
+    --from-literal={{ .Values.awsCredentials.accessKeyIdKey }}=YOUR_AWS_ACCESS_KEY_ID \
+    --from-literal={{ .Values.awsCredentials.secretAccessKeyKey }}=YOUR_AWS_SECRET_ACCESS_KEY \
+    -n {{ .Release.Namespace }}
+
+Or create it from AWS credentials file:
+
+  kubectl create secret generic {{ .Values.awsCredentials.secretName }} \
+    --from-file={{ .Values.awsCredentials.accessKeyIdKey }}=$HOME/.aws/credentials \
+    --from-file={{ .Values.awsCredentials.secretAccessKeyKey }}=$HOME/.aws/credentials \
+    -n {{ .Release.Namespace }}
+
+Restart the pods after creating the secret:
+
+  kubectl rollout restart deployment -n {{ .Release.Namespace }}
+
+{{- else }}
+
+❌ AWS credentials are DISABLED (using credential chain)
+
+The controller will use the default AWS credential chain:
+  • IAM role (if on EKS)
+  • AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables
+  • ~/.aws/credentials file
+  • Instance metadata service (EC2)
+
+To enable credentials from a Kubernetes secret, upgrade with:
+
+  helm upgrade {{ .Release.Name }} kube-s3-operator/kube-s3-operator \
+    -n {{ .Release.Namespace }} \
+    --set awsCredentials.enabled=true
+
+{{- end }}
+
+=== Verify Installation ===
+
+1. Check if pods are running:
+   kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/name=kube-s3-operator
+
+2. Check controller logs:
+   kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name=kube-s3-operator -c manager --tail=50
+
+3. Verify no errors in pod events:
+   kubectl describe pods -n {{ .Release.Namespace }} -l app.kubernetes.io/name=kube-s3-operator
+
+=== Next Steps ===
+
+Create an S3Bucket resource:
+
+  cat << EOF | kubectl apply -f -
+  apiVersion: s3.acme.io/v1alpha1
+  kind: S3Bucket
+  metadata:
+    name: my-test-bucket
+    namespace: {{ .Release.Namespace }}
+  spec:
+    bucketName: my-unique-bucket-name-$(date +%s)
+    region: us-west-2
+    locked: false
+  EOF
+
+Monitor the resource creation:
+  kubectl get s3bucket -n {{ .Release.Namespace }} -w

--- a/code/charts/kube-s3-operator/templates/deployment.yaml
+++ b/code/charts/kube-s3-operator/templates/deployment.yaml
@@ -26,16 +26,20 @@ spec:
         command:
         - /manager
         env:
+        {{- if .Values.awsCredentials.enabled }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
-              key: aws-access-key-id
-              name: aws-secret
+              key: {{ .Values.awsCredentials.accessKeyIdKey }}
+              name: {{ .Values.awsCredentials.secretName }}
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              key: aws-secret-access-key
-              name: aws-secret
+              key: {{ .Values.awsCredentials.secretAccessKeyKey }}
+              name: {{ .Values.awsCredentials.secretName }}
+        {{- else }}
+        # AWS credentials not configured - requires IAM role or external credentials provider
+        {{- end }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag

--- a/code/charts/kube-s3-operator/values.yaml
+++ b/code/charts/kube-s3-operator/values.yaml
@@ -27,6 +27,17 @@ controllerManager:
   replicas: 2
   serviceAccount:
     annotations: {}
+# AWS Configuration
+# Set awsCredentials.enabled to true to use AWS credentials from a secret
+# The secret must exist in the same namespace before deployment
+awsCredentials:
+  enabled: false
+  # Secret name containing AWS credentials
+  secretName: aws-secret
+  # Secret keys for AWS credentials
+  accessKeyIdKey: aws-access-key-id
+  secretAccessKeyKey: aws-secret-access-key
+
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:


### PR DESCRIPTION
Resolves pod deployment failure when aws-secret doesn't exist.

Supports three credential scenarios:
1. Kubernetes secret
2. IAM role (EKS/EC2)
3. AWS credential chain

Default (disabled) - uses credential chain or IAM role
Enable with: --set awsCredentials.enabled=true